### PR TITLE
FSET-1311 Use either assessor or admin sign-in url in the email changed template (new addr)

### DIFF
--- a/app/uk/gov/hmrc/fsetemailrenderer/templates/fasttrack/csrEmailChangedSentToNewAddress.scala.html
+++ b/app/uk/gov/hmrc/fsetemailrenderer/templates/fasttrack/csrEmailChangedSentToNewAddress.scala.html
@@ -8,7 +8,12 @@
     <h2 style="font-size: 32px; line-height: 1.315789474; margin: 0 0 30px 0;">Sign in using this email address and current password</h2>
     <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Your password has not been changed.</p>
     <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Visit the sign in page to continue
-        <br> (<a href="/admin/signin.html">***REMOVED***</a>)</p>
+    @if(params.parameters.getOrElse("role", "").toString == "assessor"){
+        <br> (<a href='@params.parameters("assessorSigninUrl")'>@params.parameters("assessorSigninUrl")</a>)
+    } else {
+        <br> (<a href='@params.parameters("adminSigninUrl")'>@params.parameters("adminSigninUrl")</a>)
+    }
+    </p>
 
 	<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Thank you</p>
     <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Fast Track team</p>

--- a/app/uk/gov/hmrc/fsetemailrenderer/templates/fasttrack/csrEmailChangedSentToNewAddress.scala.txt
+++ b/app/uk/gov/hmrc/fsetemailrenderer/templates/fasttrack/csrEmailChangedSentToNewAddress.scala.txt
@@ -5,7 +5,11 @@ Your email address for your account has been changed to @{params.parameters("new
 Sign in using this email address and current password
 Your password has not been changed.
 
-Visit the sign in page to continue (***REMOVED***)
+@if(params.parameters.getOrElse("role", "").toString == "assessor"){
+Visit the sign in page to continue (@params.parameters("assessorSigninUrl"))
+} else {
+Visit the sign in page to continue (@params.parameters("adminSigninUrl"))
+}
 
 Thank you
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -138,8 +138,8 @@ Dev {
   microservice {
       fasttrack {
         injectedParameters {
-          adminSigninUrl = "REPLACE ME"
-          assessorSigninUrl = "REPLACE ME"
+          adminSigninUrl = "adminSigninUrl-REPLACE-ME"
+          assessorSigninUrl = "assessorSigninUrl-REPLACE-ME"
           fromAddress = "noreply@csr.vtdev.uk"
           staticAssetUrlPrefix = "http://localhost:9032"
           staticAssetVersion = "/assets/2.230.0"


### PR DESCRIPTION
Change to use either assessor signin url or admin signin url (read from config) in the csrEmailChangedSentToNewAddress templates depending on the user's role