### PR TITLE
FSET-1619. Create new FS Assessor account and add skills

### DIFF
--- a/app/uk/gov/hmrc/fsetemailrenderer/templates/faststream/FastStreamTemplateGroup.scala
+++ b/app/uk/gov/hmrc/fsetemailrenderer/templates/faststream/FastStreamTemplateGroup.scala
@@ -45,7 +45,7 @@ object FastStreamTemplateGroup {
     ),
     FastStreamTemplate(
       templateId = "fset_faststream_external_registration_activated_no_password_email",
-      subject = Subject("New account has been created"),
+      subject = Subject("Your account has been created"),
       body = Body(html.fsetFaststreamExternalRegistrationActivatedNoPasswordEmail.f, txt.fsetFaststreamExternalRegistrationActivatedNoPasswordEmail.f)
     ),
     FastStreamTemplate(

--- a/app/uk/gov/hmrc/fsetemailrenderer/templates/faststream/fsetFaststreamRegistrationActivatedNoPasswordEmail.scala.html
+++ b/app/uk/gov/hmrc/fsetemailrenderer/templates/faststream/fsetFaststreamRegistrationActivatedNoPasswordEmail.scala.html
@@ -1,10 +1,10 @@
-@(params: uk.gov.hmrc.fsetemailrenderer.controllers.model.Params)@uk.gov.hmrc.fsetemailrenderer.templates.helpers.html.template_csr(params, "New account has been created") {
+@(params: uk.gov.hmrc.fsetemailrenderer.controllers.model.Params)@uk.gov.hmrc.fsetemailrenderer.templates.helpers.html.template_csr(params, "Your account has been created") {
     @if(params.parameters("name").toString.trim.nonEmpty){
         <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params.parameters("name")}</p>
     }
     <h3>You need to do the following to be able to sign in to your account.</h3>
     <ul>
-        <li>Visit the sign in page for the first time <a href="@{params.parameters("adminSigninUrl")}">@params.parameters("adminSigninUrl")</a></li>
+        <li>Visit the sign in page for the first time <a href="@{params.parameters("externalSigninUrl")}">@params.parameters("externalSigninUrl")</a></li>
         <li>Press "Activate account / Forgotten password"</li>
         <li>Enter the email address that this email was sent to</li>
         <li>Press "Send code", retrieve the 7-character code from your email</li>

--- a/app/uk/gov/hmrc/fsetemailrenderer/templates/faststream/fsetFaststreamRegistrationActivatedNoPasswordEmail.scala.txt
+++ b/app/uk/gov/hmrc/fsetemailrenderer/templates/faststream/fsetFaststreamRegistrationActivatedNoPasswordEmail.scala.txt
@@ -2,7 +2,7 @@
 
     You need to do the following to be able to sign in to your account.
 
-        - Visit the sign in page for the first time @params.parameters("adminSigninUrl")
+        - Visit the sign in page for the first time @params.parameters("externalSigninUrl")
         - Press "Activate account / Forgotten password"
         - Enter the email address that this email was sent to
         - Press "Send code", retrieve the 7-character code from your email


### PR DESCRIPTION
Necessary template has been added under FSET-1345. Fixing URL link in template.

4 PRs:
fset-faststream-admin-frontend
https://github.com/hmrc/fset-faststream/pull/363/files
csr-auth-provider
https://github.com/hmrc/fset-email-renderer/pull/15